### PR TITLE
Refactor post page for Gatsby Head API

### DIFF
--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Helmet } from 'react-helmet';
 import { Link, graphql } from 'gatsby';
 import styled from 'styled-components';
 import kebabCase from 'lodash/kebabCase';
@@ -47,8 +46,6 @@ const Post = ({ pageContext: { slug, prev, next }, data: { markdownRemark: postN
   return (
     <Layout>
       <Wrapper>
-        <SEO postPath={slug} postNode={postNode} postSEO />
-        <Helmet title={`${post.title} | ${config.siteTitle}`} />
         <Header>
           <Link to="/">{config.siteTitle}</Link>
         </Header>
@@ -68,6 +65,13 @@ const Post = ({ pageContext: { slug, prev, next }, data: { markdownRemark: postN
 };
 
 export default Post;
+
+export const Head = ({ pageContext: { slug }, data: { markdownRemark: postNode } }) => (
+  <>
+    <SEO postPath={slug} postNode={postNode} postSEO />
+    <title>{`${postNode.frontmatter.title} | ${config.siteTitle}`}</title>
+  </>
+);
 
 Post.propTypes = {
   pageContext: PropTypes.shape({


### PR DESCRIPTION
## Summary
- remove `react-helmet` usage in `post.js`
- export new `Head` function for Gatsby 5

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path')*

------
https://chatgpt.com/codex/tasks/task_e_6842d9dcf4408325a245f249d957331e