### PR TITLE
Refactor defaultProps to default params

### DIFF
--- a/src/components/PrevNext.js
+++ b/src/components/PrevNext.js
@@ -32,7 +32,7 @@ const Next = styled.div`
   }
 `;
 
-const PrevNext = ({ next, prev }) => (
+const PrevNext = ({ next = null, prev = null }) => (
   <Wrapper>
     {prev && (
       <Prev>
@@ -57,7 +57,3 @@ PrevNext.propTypes = {
   prev: PropTypes.object,
 };
 
-PrevNext.defaultProps = {
-  next: null,
-  prev: null,
-};

--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -35,7 +35,7 @@ const PostContent = styled.div`
   margin-top: 4rem;
 `;
 
-const Post = ({ pageContext: { slug, prev, next }, data: { markdownRemark: postNode } }) => {
+const Post = ({ pageContext: { slug, prev = null, next = null } = {}, data: { markdownRemark: postNode } }) => {
   const post = postNode.frontmatter;
 
   const disqusConfig = {
@@ -80,12 +80,6 @@ Post.propTypes = {
   }).isRequired,
 };
 
-Post.defaultProps = {
-  pageContext: PropTypes.shape({
-    next: null,
-    prev: null,
-  }),
-};
 
 export const postQuery = graphql`
   query postBySlug($slug: String!) {


### PR DESCRIPTION
## Summary
- remove `defaultProps` in `Post` and `PrevNext`
- use JavaScript default parameters instead

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path')*

------
https://chatgpt.com/codex/tasks/task_e_6842e09e81288325bf76a107e129dc49