### PR TITLE
Remove Disqus integration

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -57,12 +57,6 @@ module.exports = {
     },
     'gatsby-plugin-netlify',
     {
-      resolve: `gatsby-plugin-disqus`,
-      options: {
-        shortname: `spmcb-com`,
-      },
-    },
-    {
       resolve: `gatsby-plugin-google-gtag`,
       options: {
         // You can add multiple tracking ids and a pageview event will be fired for all of them.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "babel-plugin-styled-components": "^2.1.4",
         "gatsby": "^5.14.3",
         "gatsby-plugin-catch-links": "^5.14.0",
-        "gatsby-plugin-disqus": "^1.2.6",
         "gatsby-plugin-google-analytics": "^5.14.0",
         "gatsby-plugin-google-gtag": "^5.14.0",
         "gatsby-plugin-lodash": "^6.14.0",
@@ -11492,15 +11491,6 @@
       },
       "peerDependencies": {
         "gatsby": "^5.0.0-next"
-      }
-    },
-    "node_modules/gatsby-plugin-disqus": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-disqus/-/gatsby-plugin-disqus-1.2.6.tgz",
-      "integrity": "sha512-lGa6q7oldF3cxbwcS1dvndaxDevEBfYOIweUYOARheU0AhbDzYp4lyIvUkUwBYEWsAzIsuJNiugI6yIcQXy09g==",
-      "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/gatsby-plugin-google-analytics": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "babel-plugin-styled-components": "^2.1.4",
     "gatsby": "^5.14.3",
     "gatsby-plugin-catch-links": "^5.14.0",
-    "gatsby-plugin-disqus": "^1.2.6",
     "gatsby-plugin-google-analytics": "^5.14.0",
     "gatsby-plugin-google-gtag": "^5.14.0",
     "gatsby-plugin-lodash": "^6.14.0",

--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -4,7 +4,6 @@ import { Helmet } from 'react-helmet';
 import { Link, graphql } from 'gatsby';
 import styled from 'styled-components';
 import kebabCase from 'lodash/kebabCase';
-import { Disqus } from 'gatsby-plugin-disqus';
 import { Layout, Wrapper, Header, Subline, SEO, PrevNext } from 'components';
 import { media } from '../utils/media';
 import config from '../../config/SiteConfig';
@@ -38,11 +37,6 @@ const PostContent = styled.div`
 const Post = ({ pageContext: { slug, prev = null, next = null } = {}, data: { markdownRemark: postNode } }) => {
   const post = postNode.frontmatter;
 
-  const disqusConfig = {
-    url: `${config.siteUrl + slug}`,
-    identifier: slug,
-    title: post.title,
-  };
 
   return (
     <Layout>
@@ -59,7 +53,6 @@ const Post = ({ pageContext: { slug, prev = null, next = null } = {}, data: { ma
             <Link to={`/categories/${kebabCase(post.category)}`}>{post.category}</Link>
           </Subline>
           <PostContent dangerouslySetInnerHTML={{ __html: postNode.html }} />
-          <Disqus config={disqusConfig} />
           <PrevNext prev={prev} next={next} />
         </Content>
       </Wrapper>


### PR DESCRIPTION
## Summary
- remove gatsby-plugin-disqus from package files
- drop Disqus component from post template
- delete Disqus plugin config

## Testing
- `npm install`
- `npm run lint` *(fails: Parsing error: Class extends value [object Module] is not a constructor or null)*
- `npm run lint:js` *(fails: Parsing error: Class extends value [object Module] is not a constructor or null)*

------
https://chatgpt.com/codex/tasks/task_e_6842e57c8a0883259970a1927452ff3e