### PR TITLE
Refactor PropTypes to JSDoc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "polished": "^4.3.1",
         "postcss": "^8.5.4",
         "prismjs": "^1.30.0",
-        "prop-types": "^15.8.1",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
         "react-helmet": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "polished": "^4.3.1",
     "postcss": "^8.5.4",
     "prismjs": "^1.30.0",
-    "prop-types": "^15.8.1",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-helmet": "^6.1.0",

--- a/src/components/Article.js
+++ b/src/components/Article.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Link } from 'gatsby';
 import kebabCase from 'lodash/kebabCase';
@@ -34,6 +33,19 @@ const Excerpt = styled.p`
   margin-bottom: 1rem;
 `;
 
+/**
+ * @typedef {Object} ArticleProps
+ * @property {string} title
+ * @property {string} date
+ * @property {string} excerpt
+ * @property {string} slug
+ * @property {number} timeToRead
+ * @property {string} category
+ */
+
+/**
+ * @param {ArticleProps} props
+ */
 const Article = ({ title, date, excerpt, slug, timeToRead, category }) => {
   const firstChar = title.charAt(0);
 
@@ -54,11 +66,3 @@ const Article = ({ title, date, excerpt, slug, timeToRead, category }) => {
 
 export default Article;
 
-Article.propTypes = {
-  title: PropTypes.string.isRequired,
-  date: PropTypes.string.isRequired,
-  excerpt: PropTypes.string.isRequired,
-  slug: PropTypes.string.isRequired,
-  timeToRead: PropTypes.number.isRequired,
-  category: PropTypes.string.isRequired,
-};

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { darken, lighten } from 'polished';
 
@@ -29,6 +28,14 @@ const Content = styled.div`
   }
 `;
 
+/**
+ * @typedef {Object} HeaderProps
+ * @property {React.ReactNode | React.ReactNode[]} children
+ */
+
+/**
+ * @param {HeaderProps} props
+ */
 const Header = ({ children }) => (
   <Wrapper>
     <Content>{children}</Content>
@@ -37,6 +44,3 @@ const Header = ({ children }) => (
 
 export default Header;
 
-Header.propTypes = {
-  children: PropTypes.oneOfType([PropTypes.array, PropTypes.node]).isRequired,
-};

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -1,7 +1,6 @@
 /* eslint no-unused-expressions:0 */
 
 import React from 'react';
-import PropTypes from 'prop-types';
 import { StaticQuery, graphql } from 'gatsby';
 import styled, { ThemeProvider, createGlobalStyle } from 'styled-components';
 import SEO from './SEO';
@@ -67,6 +66,14 @@ const Footer = styled.footer`
   }
 `;
 
+/**
+ * @typedef {Object} LayoutProps
+ * @property {React.ReactNode | React.ReactNode[]} children
+ */
+
+/**
+ * @param {LayoutProps} props
+ */
 const Layout = ({ children }) => (
   <StaticQuery
     query={graphql`
@@ -93,7 +100,3 @@ const Layout = ({ children }) => (
 );
 
 export default Layout;
-
-Layout.propTypes = {
-  children: PropTypes.oneOfType([PropTypes.array, PropTypes.node]).isRequired,
-};

--- a/src/components/PrevNext.js
+++ b/src/components/PrevNext.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Link } from 'gatsby';
 
@@ -32,6 +31,15 @@ const Next = styled.div`
   }
 `;
 
+/**
+ * @typedef {Object} PrevNextProps
+ * @property {Object} [next]
+ * @property {Object} [prev]
+ */
+
+/**
+ * @param {PrevNextProps} props
+ */
 const PrevNext = ({ next = null, prev = null }) => (
   <Wrapper>
     {prev && (
@@ -52,8 +60,4 @@ const PrevNext = ({ next = null, prev = null }) => (
 
 export default PrevNext;
 
-PrevNext.propTypes = {
-  next: PropTypes.object,
-  prev: PropTypes.object,
-};
 

--- a/src/components/SEO.js
+++ b/src/components/SEO.js
@@ -1,9 +1,18 @@
 /* eslint-disable react/require-default-props */
 import React from 'react';
-import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
 import config from '../../config/SiteConfig';
 
+/**
+ * @typedef {Object} SEOProps
+ * @property {Object} [postNode]
+ * @property {string} [postPath]
+ * @property {boolean} [postSEO]
+ */
+
+/**
+ * @param {SEOProps} props
+ */
 const SEO = (props) => {
   const { postNode, postPath, postSEO } = props;
   let title;
@@ -98,8 +107,3 @@ const SEO = (props) => {
 
 export default SEO;
 
-SEO.propTypes = {
-  postNode: PropTypes.object,
-  postPath: PropTypes.string,
-  postSEO: PropTypes.bool,
-};

--- a/src/pages/categories.js
+++ b/src/pages/categories.js
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes from "prop-types";
 import { Helmet } from "react-helmet";
 import { Link, graphql } from "gatsby";
 import styled from "styled-components";
@@ -31,6 +30,14 @@ const Title = styled.h3`
   margin-bottom: 0.75rem;
 `;
 
+/**
+ * @typedef {Object} CategoryProps
+ * @property {{ group: Array<{fieldValue: string, totalCount: number}> }} data
+ */
+
+/**
+ * @param {CategoryProps} props
+ */
 const Category = ({
   data: {
     allMarkdownRemark: { group },
@@ -59,13 +66,6 @@ const Category = ({
 
 export default Category;
 
-Category.propTypes = {
-  data: PropTypes.shape({
-    allMarkdownRemark: PropTypes.shape({
-      group: PropTypes.array.isRequired,
-    }),
-  }).isRequired,
-};
 
 export const postQuery = graphql`
   query CategoriesPage {

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes from "prop-types";
 import { graphql } from "gatsby";
 import styled from "styled-components";
 import { Layout, Article, Wrapper, SectionTitle } from "components";
@@ -37,6 +36,14 @@ const Hero = styled.div`
   }
 `;
 
+/**
+ * @typedef {Object} IndexProps
+ * @property {{ edges: Array<any> }} data
+ */
+
+/**
+ * @param {IndexProps} props
+ */
 const IndexPage = ({
   data: {
     allMarkdownRemark: { edges: postEdges },
@@ -77,13 +84,6 @@ const IndexPage = ({
 
 export default IndexPage;
 
-IndexPage.propTypes = {
-  data: PropTypes.shape({
-    allMarkdownRemark: PropTypes.shape({
-      edges: PropTypes.array.isRequired,
-    }),
-  }).isRequired,
-};
 
 export const IndexQuery = graphql`
   query IndexQuery {

--- a/src/templates/category.js
+++ b/src/templates/category.js
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes from "prop-types";
 import { Helmet } from "react-helmet";
 import { Link, graphql } from "gatsby";
 import styled from "styled-components";
@@ -30,6 +29,15 @@ const Content = styled.div`
   }
 `;
 
+/**
+ * @typedef {Object} CategoryPageProps
+ * @property {{ category: string }} pageContext
+ * @property {{ allMarkdownRemark: { edges: Array<any>, totalCount: number } }} data
+ */
+
+/**
+ * @param {CategoryPageProps} props
+ */
 const Category = ({
   pageContext: { category },
   data: { allMarkdownRemark },
@@ -68,17 +76,6 @@ const Category = ({
 
 export default Category;
 
-Category.propTypes = {
-  pageContext: PropTypes.shape({
-    category: PropTypes.string.isRequired,
-  }).isRequired,
-  data: PropTypes.shape({
-    allMarkdownRemark: PropTypes.shape({
-      edges: PropTypes.array.isRequired,
-      totalCount: PropTypes.number.isRequired,
-    }),
-  }).isRequired,
-};
 
 export const postQuery = graphql`
   query CategoryPage($category: String!) {

--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
 import { Link, graphql } from 'gatsby';
 import styled from 'styled-components';
@@ -34,6 +33,15 @@ const PostContent = styled.div`
   margin-top: 4rem;
 `;
 
+/**
+ * @typedef {Object} PostPageProps
+ * @property {{ slug: string, next?: object, prev?: object }} [pageContext]
+ * @property {{ markdownRemark: object }} data
+ */
+
+/**
+ * @param {PostPageProps} props
+ */
 const Post = ({ pageContext: { slug, prev = null, next = null } = {}, data: { markdownRemark: postNode } }) => {
   const post = postNode.frontmatter;
 
@@ -62,16 +70,6 @@ const Post = ({ pageContext: { slug, prev = null, next = null } = {}, data: { ma
 
 export default Post;
 
-Post.propTypes = {
-  pageContext: PropTypes.shape({
-    slug: PropTypes.string.isRequired,
-    next: PropTypes.object,
-    prev: PropTypes.object,
-  }),
-  data: PropTypes.shape({
-    markdownRemark: PropTypes.object.isRequired,
-  }).isRequired,
-};
 
 
 export const postQuery = graphql`


### PR DESCRIPTION
## Summary
- replace runtime prop-types with JSDoc annotations
- remove `prop-types` from dependencies

## Testing
- `npm run lint:js` *(fails: Parsing error - Class extends value [object Module] is not a constructor or null)*

------
https://chatgpt.com/codex/tasks/task_e_6842ebe5aea88325826073ed1f8f42f3