### PR TITLE
Remove unused react-is dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
         "react-helmet": "^6.1.0",
-        "react-is": "^19.1.0",
         "react-typography": "^0.16.23",
         "styled-components": "^6.1.18",
         "typography": "^0.16.24"
@@ -17726,12 +17725,6 @@
       "peerDependencies": {
         "react": ">=16.3.0"
       }
-    },
-    "node_modules/react-is": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.0.tgz",
-      "integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==",
-      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.14.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-helmet": "^6.1.0",
-    "react-is": "^19.1.0",
     "react-typography": "^0.16.23",
     "styled-components": "^6.1.18",
     "typography": "^0.16.24"


### PR DESCRIPTION
## Summary
- remove `react-is` from project dependencies

## Testing
- `npm run lint` *(fails: Parsing error: Class extends value [object Module] is not a constructor or null)*

------
https://chatgpt.com/codex/tasks/task_e_6842f86b5f18832594e96c7028e4b5a6