### PR TITLE
Fix eslint script

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,11 @@
 {
   "extends": ["airbnb", "prettier"],
-  "parser": "babel-eslint",
+  "parser": "@babel/eslint-parser",
   "parserOptions": {
+    "requireConfigFile": false,
+    "babelOptions": {
+      "presets": ["@babel/preset-react"]
+    },
     "ecmaVersion": 2017,
     "ecmaFeatures": {
       "experimentalObjectRestSpread": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "typography": "^0.16.24"
       },
       "devDependencies": {
-        "babel-eslint": "^10.1.0",
+        "@babel/eslint-parser": "^7.23.3",
         "babel-preset-env": "^1.7.0",
         "eslint": "^8.2.0",
         "eslint-config-airbnb": "^19.0.4",
@@ -5899,6 +5899,7 @@
       "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
       "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
       "deprecated": "babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "@babel/parser": "^7.7.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "lint:md": "prettier --write blog/**/*.md"
   },
   "devDependencies": {
-    "babel-eslint": "^10.1.0",
+    "@babel/eslint-parser": "^7.23.3",
     "babel-preset-env": "^1.7.0",
     "eslint": "^8.2.0",
     "eslint-config-airbnb": "^19.0.4",


### PR DESCRIPTION
## Summary
- use `@babel/eslint-parser` instead of deprecated `babel-eslint`
- wire parser to Babel presets so ESLint can parse JSX correctly

## Testing
- `npm run lint:js`

------
https://chatgpt.com/codex/tasks/task_e_6842fbc2cd508325bcb4d64225776ae0