### PR TITLE
Improve gatsby-node

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,96 +1,83 @@
 const path = require('path');
 const kebabCase = require('./src/utils/kebabCase');
 
+// Gatsby node APIs used to enhance or extend the default build process.
+
+// Add a slug field to markdown nodes based on `slug` or `title` in frontmatter.
 exports.onCreateNode = ({ node, actions }) => {
   const { createNodeField } = actions;
-  let slug;
-  if (node.internal.type === 'MarkdownRemark') {
-    if (
-      Object.prototype.hasOwnProperty.call(node, 'frontmatter') &&
-      Object.prototype.hasOwnProperty.call(node.frontmatter, 'slug')
-    ) {
-      slug = `/${kebabCase(node.frontmatter.slug)}`;
-    } else if (
-      Object.prototype.hasOwnProperty.call(node, 'frontmatter') &&
-      Object.prototype.hasOwnProperty.call(node.frontmatter, 'title')
-    ) {
-      slug = `/${kebabCase(node.frontmatter.title)}`;
-    }
-    createNodeField({ node, name: 'slug', value: slug });
-  }
+
+  if (node.internal.type !== 'MarkdownRemark') return;
+
+  const slugSource = node.frontmatter?.slug || node.frontmatter?.title;
+  if (!slugSource) return;
+
+  createNodeField({
+    node,
+    name: 'slug',
+    value: `/${kebabCase(slugSource)}`,
+  });
 };
 
-exports.createPages = ({ graphql, actions }) => {
+// Query markdown files and create the necessary post and category pages.
+exports.createPages = async ({ graphql, actions }) => {
   const { createPage } = actions;
 
-  return new Promise((resolve, reject) => {
-    const postPage = path.resolve('src/templates/post.js');
-    const categoryPage = path.resolve('src/templates/category.js');
-    resolve(
-      graphql(`
-        {
-          posts: allMarkdownRemark {
-            edges {
-              node {
-                fields {
-                  slug
-                }
-                frontmatter {
-                  title
-                  category
-                }
-              }
+  const postTemplate = path.resolve('src/templates/post.js');
+  const categoryTemplate = path.resolve('src/templates/category.js');
+
+  const result = await graphql(`
+    {
+      posts: allMarkdownRemark {
+        edges {
+          node {
+            fields {
+              slug
+            }
+            frontmatter {
+              title
+              category
             }
           }
         }
-      `).then((result) => {
-        if (result.errors) {
-          console.log(result.errors);
-          reject(result.errors);
-        }
+      }
+    }
+  `);
 
-        const posts = result.data.posts.edges;
+  if (result.errors) {
+    throw result.errors;
+  }
 
-        posts.forEach((edge, index) => {
-          const next = index === 0 ? null : posts[index - 1].node;
-          const prev = index === posts.length - 1 ? null : posts[index + 1].node;
+  const posts = result.data.posts.edges;
 
-          createPage({
-            path: edge.node.fields.slug,
-            component: postPage,
-            context: {
-              slug: edge.node.fields.slug,
-              prev,
-              next,
-            },
-          });
-        });
+  posts.forEach((edge, index) => {
+    const next = index === 0 ? null : posts[index - 1].node;
+    const prev = index === posts.length - 1 ? null : posts[index + 1].node;
 
-        let categories = [];
+    createPage({
+      path: edge.node.fields.slug,
+      component: postTemplate,
+      context: {
+        slug: edge.node.fields.slug,
+        prev,
+        next,
+      },
+    });
+  });
 
-        posts.forEach((edge) => {
-          if (edge?.node?.frontmatter?.category) {
-            categories = categories.concat(edge.node.frontmatter.category);
-          }
-        });
+  const categories = Array.from(new Set(posts.flatMap((edge) => edge.node.frontmatter.category || [])));
 
-        categories = Array.from(new Set(categories));
-
-        categories.forEach((category) => {
-          createPage({
-            path: `/categories/${kebabCase(category)}`,
-            component: categoryPage,
-            context: {
-              category,
-            },
-          });
-        });
-      })
-    );
+  categories.forEach((category) => {
+    createPage({
+      path: `/categories/${kebabCase(category)}`,
+      component: categoryTemplate,
+      context: { category },
+    });
   });
 };
 
 exports.onCreateWebpackConfig = ({ stage, actions }) => {
+  // Allow absolute imports from the `src` directory.
   actions.setWebpackConfig({
     resolve: {
       modules: [path.resolve(__dirname, 'src'), 'node_modules'],


### PR DESCRIPTION
## Summary
- simplify `gatsby-node.js` logic
- document Gatsby Node hooks with comments

## Testing
- `npx prettier --check gatsby-node.js --single-quote --trailing-comma es5 --print-width 120`
- `npm run lint:js:fix` *(fails: Invalid option '--ignore-path')*

------
https://chatgpt.com/codex/tasks/task_e_68431de55de08325b0f07bffab2b7604