### PR TITLE
Fix imports without webpack alias

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -76,11 +76,3 @@ exports.createPages = async ({ graphql, actions }) => {
   });
 };
 
-exports.onCreateWebpackConfig = ({ stage, actions }) => {
-  // Allow absolute imports from the `src` directory.
-  actions.setWebpackConfig({
-    resolve: {
-      modules: [path.resolve(__dirname, 'src'), 'node_modules'],
-    },
-  });
-};

--- a/src/pages/categories.js
+++ b/src/pages/categories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Helmet } from 'react-helmet';
 import { Link, graphql } from 'gatsby';
 import styled from 'styled-components';
-import { Layout, Wrapper, Header, SectionTitle } from 'components';
+import { Layout, Wrapper, Header, SectionTitle } from '../components';
 import kebabCase from '../utils/kebabCase';
 import { media } from '../utils/media';
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { graphql } from 'gatsby';
 import styled from 'styled-components';
-import { Layout, Article, Wrapper, SectionTitle } from 'components';
+import { Layout, Article, Wrapper, SectionTitle } from '../components';
 import { media } from '../utils/media';
 
 const Content = styled.div`

--- a/src/templates/category.js
+++ b/src/templates/category.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Helmet } from 'react-helmet';
 import { Link, graphql } from 'gatsby';
 import styled from 'styled-components';
-import { Layout, Wrapper, Header, SubLine, Article, SectionTitle } from 'components';
+import { Layout, Wrapper, Header, SubLine, Article, SectionTitle } from '../components';
 import { media } from '../utils/media';
 import config from '../../config/SiteConfig';
 

--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Helmet } from 'react-helmet';
 import { Link, graphql } from 'gatsby';
 import styled from 'styled-components';
-import { Layout, Wrapper, Header, SubLine, SEO, PrevNext } from 'components';
+import { Layout, Wrapper, Header, SubLine, SEO, PrevNext } from '../components';
 import kebabCase from '../utils/kebabCase';
 import { media } from '../utils/media';
 import config from '../../config/SiteConfig';


### PR DESCRIPTION
## Summary
- remove custom webpack module alias in `gatsby-node.js`
- update components imports to use relative paths

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path')*

------
https://chatgpt.com/codex/tasks/task_e_684324968cac83258486441b1d51834e