### PR TITLE
Fix category calculation

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -65,7 +65,11 @@ exports.createPages = async ({ graphql, actions }) => {
     });
   });
 
-  const categories = Array.from(new Set(posts.flatMap((edge) => edge.node.frontmatter.category || [])));
+  const categories = Array.from(
+    new Set(
+      posts.map((edge) => edge.node.frontmatter.category).filter(Boolean),
+    ),
+  );
 
   categories.forEach((category) => {
     createPage({


### PR DESCRIPTION
## Summary
- compute categories array by mapping over posts and filtering out falsy values

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path')*

------
https://chatgpt.com/codex/tasks/task_e_684326097060832581373f06b8ff8cd3