### PR TITLE
Add 404 page

### DIFF
--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { Link } from 'gatsby';
+import { Helmet } from 'react-helmet';
+import styled from 'styled-components';
+import { Layout, Wrapper, Header } from '../components';
+import config from '../../config/SiteConfig';
+
+const Content = styled.div`
+  grid-column: 2;
+  padding: 2rem 4rem;
+  text-align: center;
+`;
+
+function NotFoundPage() {
+  return (
+    <Layout>
+      <Wrapper>
+        <Header>
+          <Link to="/">{config.siteTitle}</Link>
+        </Header>
+        <Content>
+          <h1>Page not found</h1>
+          <p>
+            Sorry, we couldn&apos;t find what you were looking for. <Link to="/">Go back home</Link>.
+          </p>
+        </Content>
+      </Wrapper>
+    </Layout>
+  );
+}
+
+export default NotFoundPage;
+
+export function Head() {
+  return <Helmet title={`404 | ${config.siteTitle}`} />;
+}


### PR DESCRIPTION
## Summary
- add a simple 404 page with header and link to home

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68432a9914c88325b6b7b5e93618ee3c