### PR TITLE
Fix prev/next order

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -28,7 +28,7 @@ exports.createPages = async ({ graphql, actions }) => {
 
   const result = await graphql(`
     {
-      posts: allMarkdownRemark {
+      posts: allMarkdownRemark(sort: { frontmatter: { date: DESC } }) {
         edges {
           node {
             fields {


### PR DESCRIPTION
## Summary
- sort posts by `frontmatter.date` when generating pages

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68439b85ef5c832591186558ed780969